### PR TITLE
Adjust params and comments

### DIFF
--- a/pipelines/ElasticsearchDocRetrieval.yaml
+++ b/pipelines/ElasticsearchDocRetrieval.yaml
@@ -1,4 +1,4 @@
-# A pipeline for TXT and PDFs simultaneously, retrieval is done only with Elasticsearch
+# A pipeline for converting both TXT and PDFs simultaneously, retrieval is done only with Elasticsearch
 version: '1.3.0'
 name: 'Elasticsearch_indexing'
 

--- a/pipelines/HybridDocRetrieval.yaml
+++ b/pipelines/HybridDocRetrieval.yaml
@@ -1,11 +1,10 @@
-#A pipeline that combines a dense Retriever with a keyword-based Retriever
+#A pipeline that combines a dense Retriever with a keyword-based Retriever for English texts
 version: '1.3.0'
 name: 'hybrid_pipeline'
 
 components:
   - name: DocumentStore
     type: DeepsetCloudDocumentStore
-    params: {}
   - name: ESRetriever
     type: ElasticsearchRetriever
     params:
@@ -14,7 +13,7 @@ components:
     type: EmbeddingRetriever
     params:
       document_store: DocumentStore
-      embedding_model: sentence-transformers/msmarco-distilbert-multilingual-en-de-v2-tmp-lng-aligned
+      embedding_model: sentence-transformers/multi-qa-mpnet-base-dot-v1
       model_format: sentence_transformers
       top_k: 20
   - name: JoinResults
@@ -23,13 +22,13 @@ components:
       join_mode: reciprocal_rank_fusion
   - name: TextFileConverter
     type: TextConverter
-    params: {}
   - name: Preprocessor
     type: PreProcessor
     params:
-      split_by: passage
-      split_length: 1
-      split_respect_sentence_boundary: false
+      split_by: word
+      split_length: 500
+      split_overlap: 50
+      split_respect_sentence_boundary: True
 
 pipelines:
   - name: query

--- a/pipelines/englishqa.yaml
+++ b/pipelines/englishqa.yaml
@@ -1,4 +1,4 @@
-#A default pipeline with a good embedding base Retriever and a Reader model
+#A default English QA pipeline with a good embedding based Retriever and a large Reader model
 version: '1.3.0'
 name: 'QA_en'
 
@@ -16,7 +16,7 @@ components:
   - name: Reader
     type: FARMReader
     params:
-      model_name_or_path: deepset/roberta-base-squad2
+      model_name_or_path: deepset/roberta-large-squad2
       context_window_size: 700
   - name: TextFileConverter
     type: TextConverter
@@ -25,7 +25,7 @@ components:
     params:
       split_by: word
       split_length: 250
-      split_overlap: 30
+      split_overlap: 50
       split_respect_sentence_boundary: True
 
 pipelines:

--- a/pipelines/englishqa.yaml
+++ b/pipelines/englishqa.yaml
@@ -1,4 +1,4 @@
-#A default English QA pipeline with a good embedding based Retriever and a large Reader model
+#A default English QA pipeline with a good embedding based Retriever and a distilled Reader model
 version: '1.3.0'
 name: 'QA_en'
 

--- a/pipelines/englishqa.yaml
+++ b/pipelines/englishqa.yaml
@@ -16,7 +16,7 @@ components:
   - name: Reader
     type: FARMReader
     params:
-      model_name_or_path: deepset/roberta-large-squad2
+      model_name_or_path: deepset/roberta-base-squad2-distilled
       context_window_size: 700
   - name: TextFileConverter
     type: TextConverter

--- a/pipelines/germanqa.yaml
+++ b/pipelines/germanqa.yaml
@@ -1,4 +1,4 @@
-#A default German pipeline with EmbeddingRetriever and a German QA model
+#A default German pipeline with multilingual EmbeddingRetriever and a German QA model
 version: '1.3.0'
 name: 'QA_de'
 
@@ -17,7 +17,7 @@ components:
   - name: Reader
     type: FARMReader
     params:
-      model_name_or_path: deepset/gelectra-base-germanquad
+      model_name_or_path: deepset/gelectra-large-germanquad
       context_window_size: 700
   - name: TextFileConverter
     type: TextConverter
@@ -25,8 +25,8 @@ components:
     type: PreProcessor
     params:
       split_by: word
-      split_length: 250
-      split_overlap: 30
+      split_length: 200
+      split_overlap: 50
       split_respect_sentence_boundary: True
 
 pipelines:


### PR DESCRIPTION
- Fix splitting of text for HybridDocRetrieval.yaml
- Adjust splitting for German (because longer words)
- Use large QA models (they work much better especially on out of domain data) for German and the distilled version for English
- update comments
- use more standard sentence transformers (not the distilbert en de aligned v2)
- remove empty para list

Furthermore we could add comments explaining each part, e.g. as Aga did in our [docs](https://docs.cloud.deepset.ai/docs/create-a-pipeline-using-a-yaml-file)
