### PR TITLE
feat: Made language param explicit in the yaml templates

### DIFF
--- a/pipelines/DenseDocSearch.yaml
+++ b/pipelines/DenseDocSearch.yaml
@@ -34,6 +34,7 @@ components:
       split_length: 250 # The max number of words in a document
       split_overlap: 30 # Enables the sliding window approach
       split_respect_sentence_boundary: True # Retains complete sentences in split documents
+      language: en # Used by NLTK to best detect the sentence boundaries for that language
 
 # Here you define how the nodes are organized in the pipelines
 # For each node, specify its input

--- a/pipelines/HybridDocSearch.yaml
+++ b/pipelines/HybridDocSearch.yaml
@@ -43,6 +43,7 @@ components:
       split_length: 250 # The max number of words in a document
       split_overlap: 30 # Enables the sliding window approach
       split_respect_sentence_boundary: True # Retains complete sentences in split documents
+      language: en # Used by NLTK to best detect the sentence boundaries for that language
 
 # Here you define how the nodes are organized in the pipelines
 # For each node, specify its input

--- a/pipelines/QuestionAnswering_de.yaml
+++ b/pipelines/QuestionAnswering_de.yaml
@@ -42,6 +42,7 @@ components:
       split_length: 250 # The max number of words in a document
       split_overlap: 50 # Enables the sliding window approach
       split_respect_sentence_boundary: True # Retains complete sentences in split documents
+      language: de # Used by NLTK to best detect the sentence boundaries for that language
 
 # Here you define how the nodes are organized in the pipelines
 # For each node, specify its input

--- a/pipelines/QuestionAnswering_en.yaml
+++ b/pipelines/QuestionAnswering_en.yaml
@@ -39,6 +39,7 @@ components:
       split_length: 250 # The max number of words in a document
       split_overlap: 50 # Enables the sliding window approach
       split_respect_sentence_boundary: True # Retains complete sentences in split documents
+      language: en # Used by NLTK to best detect the sentence boundaries for that language
 
 # Here you define how the nodes are organized in the pipelines
 # For each node, specify its input

--- a/pipelines/SparseDocSearch_BM25.yaml
+++ b/pipelines/SparseDocSearch_BM25.yaml
@@ -33,6 +33,7 @@ components:
       split_length: 500 # The max number of words in a document
       split_overlap: 30 # Enables the sliding window approach
       split_respect_sentence_boundary: True # Retains complete sentences in split documents
+      language: en # Used by NLTK to best detect the sentence boundaries for that language
 
 # Here you define how the nodes are organized in the pipelines
 # For each node, specify its input


### PR DESCRIPTION
I made the language parameter explicit in the yaml definition for the PreProcessor. It is `en` by default and should be changed by the user depending on the language of the docs being used. I've also updated the German QA pipeline to use `de`. 