### PR TITLE
Update QuestionAnswering_de.yaml

### DIFF
--- a/pipelines/QuestionAnswering_de.yaml
+++ b/pipelines/QuestionAnswering_de.yaml
@@ -14,7 +14,7 @@ components:
   - name: DocumentStore
     type: DeepsetCloudDocumentStore # The only supported document store in deepset Cloud
     params:
-      similarity: cosine # Recommended for sentence transformer models
+      similarity: cosine # Recommended similarity for paraphrase-multilingual-mpnet-base-v2
   - name: Retriever # Selects the most relevant documents from the document store and then passes them on to the Reader
     type: EmbeddingRetriever # Uses a Transformer model to encode the document and the query
     params:


### PR DESCRIPTION
Updated comment on why the cosine similarity is chosen. It was incorrect to say that it is recommended for all sentence transformers models. You can see [here](https://docs.cloud.deepset.ai/docs/language-models-in-deepset-cloud#models-for-information-retrieval) which similarity measures we recommend based on the model. We extracted this information from this [website](https://www.sbert.net/docs/pretrained_models.html) originally. 